### PR TITLE
Link to slides from event pages

### DIFF
--- a/_events/software-demos/event-019.md
+++ b/_events/software-demos/event-019.md
@@ -23,6 +23,9 @@ last_modified_at: 2020-08-31
 registration_url: https://indico.scc.kit.edu/event/913/
 meeting_url: https://zoom.us/j/98656860237?pwd=dVVVZUFSdXdjRTdscnU4U2drWXNsdz09
 recording_url: https://youtu.be/_uRKBdEHhS0
+slides:
+  - "Part 1": https://indico.scc.kit.edu/event/913/attachments/3608/5295/go
+  - "Part 2": https://indico.scc.kit.edu/event/913/attachments/3608/5296/go
 ---
 Code and data are important research output and integral to a full understanding of research findings and experimental approaches in a paper. However, traditional research articles seldom have these embedded in the manuscript's narrative, but instead, leave them as "supplementary materials", if they are openly available.
 

--- a/_includes/slides-button.html
+++ b/_includes/slides-button.html
@@ -1,0 +1,21 @@
+{% if page.slides %}
+{% if page.slides[0] %}
+<select class="btn btn--success registration-menu" onchange="if (this.value) window.location.href=this.value">
+    <option value="" selected disabled hidden >&#xf15c; Slides &nbsp;&nbsp;</option>
+
+    {% for hash in page.slides -%}
+    {% for item in hash %}
+    <option value="{{ item[1] }}">{{ item[0] }}</option>
+    {% endfor %}
+    {% endfor -%}
+</select>
+{% else %}
+<a class="btn btn--success" href="{{ page.slides }}">
+  <i class="fas fa-file-alt"></i> Slides
+</a>
+{% endif %}
+{% else %}
+<span class="notice--info">
+  <i>Slides will be available soon</i>
+</span>
+{% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -11,6 +11,7 @@ layout: single
 {% include event-supplements.html %}
 </p>
 {% include registration-button.html %}
+{% include slides-button.html %}
 {% include zoom-button.html %}
 {% include team-button.html team=page.category %}
 {%- capture download_link %}/downloads/{{ page.id | split: '/' | last }}.pdf{%- endcapture %}


### PR DESCRIPTION
Add a button to event pages for users to access/download the slides from an
event. Supports a single link or an array of hashes providing description-link
pairs.

Only slides for event-019 have been added so far as these are the only ones
uploaded to Indico. If there are any others available elsewhere then let me
know and I'll add them.

This PR is ready for review.